### PR TITLE
Fix union arms & consts

### DIFF
--- a/lib/xdrgen/generators/elixir.rb
+++ b/lib/xdrgen/generators/elixir.rb
@@ -398,7 +398,7 @@ module Xdrgen
                 end
                 arm.cases.each_with_index do |acase, o|
                   switch = if acase.value.is_a?(AST::Identifier)
-                    "#{member_name(acase.value)}:"
+                    "#{acase.value.text_value}:"
                   else
                     "#{acase.value.text_value} =>"
                   end
@@ -539,10 +539,6 @@ module Xdrgen
           end
         end
         value
-      end
-
-      def member_name(member)
-        name(member).underscore.upcase
       end
 
       def type_reference(decl, container_name)

--- a/lib/xdrgen/generators/elixir.rb
+++ b/lib/xdrgen/generators/elixir.rb
@@ -5,6 +5,8 @@ module Xdrgen
 
       def generate
         @constants = Hash.new
+
+        render_consts_definitions(@top)
         render_definitions(@top)
         render_base_classes
       end
@@ -13,6 +15,11 @@ module Xdrgen
       def render_definitions(node)
         node.definitions.each{|n| render_definition n }
         node.namespaces.each{|n| render_definitions n }
+      end
+
+      def render_consts_definitions(node)
+        node.definitions.each{|n| render_consts n }
+        node.namespaces.each{|n| render_consts_definitions n }
       end
 
       def render_nested_definitions(defn)
@@ -32,7 +39,12 @@ module Xdrgen
           render_union defn
         when AST::Definitions::Typedef ;
           render_typedef(defn, false)
-        when AST::Definitions::Const ;
+        end
+      end
+
+      def render_consts(defn)
+        case defn
+        when AST::Definitions::Const;
           render_const defn
         end
       end


### PR DESCRIPTION
## Description

Validation was added so that constants are loaded into the hash first, to avoid the error of using a constant without being previously created. Also, it was validated that in the unions the name does not have an underscore